### PR TITLE
fix(collections): hardened access control in product pages and media collections as well as payload config file

### DIFF
--- a/collections/Media.ts
+++ b/collections/Media.ts
@@ -1,20 +1,22 @@
 import type { CollectionConfig } from 'payload'
+import { createTitle } from './utils';
 
 export const Media: CollectionConfig = {
   slug: 'media',
   access: {
-    read: () => true,
+    read: () => true,                 // public can read products
+    create: ({ req }) => !!req.user,  // only logged-in admins
+    update: ({ req }) => !!req.user,
+    delete: ({ req }) => !!req.user,
   },
   fields: [
     {
       name: 'alt',
       type: 'text',
-      // required: true,
       hooks: {
         beforeChange: [({ data, value }): string => {
           if (!value) {
-            const title = data.filename.split()[0];
-            return title;
+            return createTitle(data.filename);
           } else return value
         }]
       }
@@ -22,3 +24,4 @@ export const Media: CollectionConfig = {
   ],
   upload: true,
 }
+

--- a/collections/Product-Pages.ts
+++ b/collections/Product-Pages.ts
@@ -9,7 +9,10 @@ export const ProductPages: CollectionConfig = {
         group: 'Store',           // Optional: groups this collection in the sidebar
     },
     access: {
-        read: () => true,
+        read: () => true,                 // public can read products
+        create: ({ req }) => !!req.user,  // only logged-in admins
+        update: ({ req }) => !!req.user,
+        delete: ({ req }) => !!req.user,
     },
     fields: [
         {

--- a/collections/Products.ts
+++ b/collections/Products.ts
@@ -74,7 +74,6 @@ export const Products: CollectionConfig = {
     // Optional: who can do what
     access: {
         read: () => true,                 // public can read products
-        // create: () => true,                 // public can read products
         create: ({ req }) => !!req.user,  // only logged-in admins
         update: ({ req }) => !!req.user,
         delete: ({ req }) => !!req.user,

--- a/collections/utils.ts
+++ b/collections/utils.ts
@@ -1,0 +1,11 @@
+
+/** Utility Function to get filenames without the extension. If the  titleFragments array is longer than two (i.e the file has more than one dot in its name) it cocantenates every element except the last one and returns the cocantenated string */
+export function createTitle(filename:string): string {
+  const titleFragments = filename.split('.');
+  if(titleFragments.length > 2){
+    titleFragments.pop();
+    return titleFragments.reduce((a,b) => b + a, "");
+  }else{
+    return titleFragments[0];
+  }
+}

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -18,18 +18,7 @@ import { ProductPages } from "./collections/Product-Pages";
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
 
-const requiredEnvVars = {
-DATABASE_URL: process.env.DATABASE_URL,
-PAYLOAD_SECRET:  process.env.PAYLOAD_SECRET,
-BLOB_READ_WRITE_TOKEN:process.env.BLOB_READ_WRITE_TOKEN
-}
-
-for(const [key, value] of Object.entries(requiredEnvVars)){
-  if(requiredEnvVars[key] == undefined || value == ""){
-    throw new Error(`Missing env var ${key}`);
-    
-  }
-}
+checkEnvs();
 
 export default buildConfig({
   admin: {
@@ -60,3 +49,21 @@ export default buildConfig({
   })
   ],
 });
+
+function checkEnvs(): void{
+const requiredEnvVars = {
+DATABASE_URL: process.env.DATABASE_URL,
+PAYLOAD_SECRET:  process.env.PAYLOAD_SECRET,
+BLOB_READ_WRITE_TOKEN:process.env.BLOB_READ_WRITE_TOKEN
+}
+
+const missingEnvs: Array<string> = [];
+for(const [key, value] of Object.entries(requiredEnvVars)){
+  if(value == undefined || value.trim() == ""){
+   missingEnvs.push(key);
+  }
+}
+if(missingEnvs.length > 0){
+  throw new Error(`Missing environment variables ${missingEnvs.join("  ")}`);
+}
+}


### PR DESCRIPTION
fixed a bug in product-pages.ts and  media.ts that allowed anyone to upload files. 

fix(payload-config): fixed env bug that would throw when one env was missing instead of showing all the envs that are missing, similarly fixed a bug that compared value to an empty string without trimming causing envs consisting of just whitespace to pass